### PR TITLE
Force use of conda command for constructor

### DIFF
--- a/tools/run_constructor.sh
+++ b/tools/run_constructor.sh
@@ -7,7 +7,7 @@ export PYTHONUTF8=1
 echo "Running constructor recipe ${RECIPE_DIR} in verbose mode"
 
 # Allow "./tools/build_local.sh --dry-run" to pass the --dry-run arg
-EXTRA_ARGS=""
+EXTRA_ARGS="--conda-exe $(type -p conda)"
 for VAR in "$@"
 do
     if [[ "$VAR" == "--dry-run" ]]; then


### PR DESCRIPTION
This may be required because the `menu_packages` option is not fully implemented when `micromamba` is used as the `--conda-exe` binary. See <https://github.com/conda/constructor/blob/main/CONSTRUCT.md#menu_packages>.